### PR TITLE
Fix Authorization header case sensitivity

### DIFF
--- a/src/main/kotlin/ai/masaic/openresponses/api/service/MasaicCompletionService.kt
+++ b/src/main/kotlin/ai/masaic/openresponses/api/service/MasaicCompletionService.kt
@@ -262,7 +262,7 @@ class MasaicCompletionService(
         modelName: String,
     ): OpenAIClient {
         val authHeader =
-            headers.getFirst("Authorization")
+            headers.getFirst("Authorization") ?: headers.getFirst("authorization")
                 ?: throw IllegalArgumentException("api-key is missing.")
 
         val credential =

--- a/src/main/kotlin/ai/masaic/openresponses/api/service/MasaicCompletionService.kt
+++ b/src/main/kotlin/ai/masaic/openresponses/api/service/MasaicCompletionService.kt
@@ -232,7 +232,7 @@ class MasaicCompletionService(
     private fun createHeadersBuilder(headers: MultiValueMap<String, String>): Headers.Builder {
         val headerBuilder = Headers.builder()
         headers
-            .filter { it.key == "Authorization" }
+            .filter { it.key.equals("Authorization", ignoreCase = true) }
             .forEach { (key, value) -> headerBuilder.put(key, value) }
         return headerBuilder
     }

--- a/src/main/kotlin/ai/masaic/openresponses/api/service/MasaicResponseService.kt
+++ b/src/main/kotlin/ai/masaic/openresponses/api/service/MasaicResponseService.kt
@@ -400,7 +400,7 @@ class MasaicResponseService(
     private fun createHeadersBuilder(headers: MultiValueMap<String, String>): Headers.Builder {
         val headerBuilder = Headers.builder()
         headers
-            .filter { it.key == "Authorization" }
+            .filter { it.key.equals("Authorization", ignoreCase = true) }
             .forEach { (key, value) -> headerBuilder.put(key, value) }
         return headerBuilder
     }

--- a/src/main/kotlin/ai/masaic/openresponses/api/service/MasaicResponseService.kt
+++ b/src/main/kotlin/ai/masaic/openresponses/api/service/MasaicResponseService.kt
@@ -449,7 +449,7 @@ class MasaicResponseService(
         request: ResponseCreateParams.Body,
     ): OpenAIClient {
         val authHeader =
-            headers.getFirst("Authorization")
+            headers.getFirst("Authorization") ?: headers.getFirst("authorization")
                 ?: throw IllegalArgumentException("api-key is missing.")
 
         val credential =

--- a/src/test/kotlin/ai/masaic/openresponses/api/service/MasaicCompletionServiceTest.kt
+++ b/src/test/kotlin/ai/masaic/openresponses/api/service/MasaicCompletionServiceTest.kt
@@ -219,11 +219,12 @@ class MasaicCompletionServiceTest {
             runTest {
                 // Given
                 val request = createDefaultRequest()
-                val headers = createDefaultHeaders().also {
-                    it.clear()
-                    it.add("authorization", defaultAuthHeader)
-                    it.add("X-B3-TraceId", defaultTraceId)
-                }
+                val headers =
+                    createDefaultHeaders().also {
+                        it.clear()
+                        it.add("authorization", defaultAuthHeader)
+                        it.add("X-B3-TraceId", defaultTraceId)
+                    }
                 val queryParams = LinkedMultiValueMap<String, String>()
                 val expectedCompletion = mockk<ChatCompletion>(relaxed = true)
 

--- a/src/test/kotlin/ai/masaic/openresponses/api/service/MasaicCompletionServiceTest.kt
+++ b/src/test/kotlin/ai/masaic/openresponses/api/service/MasaicCompletionServiceTest.kt
@@ -215,6 +215,33 @@ class MasaicCompletionServiceTest {
             }
 
         @Test
+        fun `should accept lowercase authorization header`() =
+            runTest {
+                // Given
+                val request = createDefaultRequest()
+                val headers = createDefaultHeaders().also {
+                    it.clear()
+                    it.add("authorization", defaultAuthHeader)
+                    it.add("X-B3-TraceId", defaultTraceId)
+                }
+                val queryParams = LinkedMultiValueMap<String, String>()
+                val expectedCompletion = mockk<ChatCompletion>(relaxed = true)
+
+                coEvery {
+                    openAICompletionService.create(any(), any(), any())
+                } returns expectedCompletion
+
+                // When
+                val result = masaicCompletionService.createCompletion(request, headers, queryParams)
+
+                // Then
+                assertSame(expectedCompletion, result)
+                coVerify(exactly = 1) {
+                    openAICompletionService.create(any(), any(), any())
+                }
+            }
+
+        @Test
         fun `should extract model name correctly when using provider format`() =
             runTest {
                 // Given

--- a/src/test/kotlin/ai/masaic/openresponses/api/service/MasaicResponseServiceTest.kt
+++ b/src/test/kotlin/ai/masaic/openresponses/api/service/MasaicResponseServiceTest.kt
@@ -146,6 +146,51 @@ class MasaicResponseServiceTest {
         }
 
     @Test
+    fun `createResponse should accept lowercase authorization header`() =
+        runBlocking {
+            // Given
+            val request =
+                mockk<ResponseCreateParams.Body> {
+                    every { input() } returns ResponseCreateParams.Input.ofText("Test")
+                    every { model() } returns ResponsesModel.ofString("gpt-4")
+                    every { instructions() } returns Optional.empty()
+                    every { reasoning() } returns Optional.empty()
+                    every { parallelToolCalls() } returns Optional.of(true)
+                    every { maxOutputTokens() } returns Optional.of(256)
+                    every { include() } returns Optional.empty()
+                    every { metadata() } returns Optional.empty()
+                    every { store() } returns Optional.of(true)
+                    every { temperature() } returns Optional.of(0.7)
+                    every { topP() } returns Optional.of(0.9)
+                    every { truncation() } returns Optional.empty()
+                    every { _additionalProperties() } returns emptyMap()
+
+                    every { text() } returns Optional.of(ResponseTextConfig.builder().build())
+                    every { user() } returns Optional.of("someUser")
+                    every { toolChoice() } returns Optional.of(ResponseCreateParams.ToolChoice.ofOptions(ToolChoiceOptions.AUTO))
+                    every { tools() } returns Optional.of(listOf())
+                }
+            val headers: MultiValueMap<String, String> = LinkedMultiValueMap()
+            headers.add("authorization", "Bearer testKey")
+            val queryParams: MultiValueMap<String, String> = LinkedMultiValueMap()
+
+            val expectedResponse = mockk<Response>()
+            coEvery {
+                openAIResponseService.create(ofType<OpenAIClient>(), any(), any())
+            } returns expectedResponse
+
+            // When
+            val result = masaicResponseService.createResponse(request, headers, queryParams)
+
+            // Then
+            assertSame(expectedResponse, result)
+            coVerify(exactly = 1) {
+                openAIResponseService.create(ofType<OpenAIClient>(), any(), any())
+            }
+            confirmVerified(openAIResponseService)
+        }
+
+    @Test
     fun `createStreamingResponse should return a Flow of ServerSentEvent`() =
         runBlocking {
             // Given

--- a/src/test/kotlin/ai/masaic/openresponses/api/service/MasaicResponseServiceTest.kt
+++ b/src/test/kotlin/ai/masaic/openresponses/api/service/MasaicResponseServiceTest.kt
@@ -151,6 +151,7 @@ class MasaicResponseServiceTest {
             // Given
             val request =
                 mockk<ResponseCreateParams.Body> {
+                    every { previousResponseId() } returns Optional.empty()
                     every { input() } returns ResponseCreateParams.Input.ofText("Test")
                     every { model() } returns ResponsesModel.ofString("gpt-4")
                     every { instructions() } returns Optional.empty()


### PR DESCRIPTION
## Summary
- ensure Authorization header is recognized regardless of case
- test lowercase authorization headers in response and completion services