### PR TITLE
Fix tool call env var message

### DIFF
--- a/src/main/kotlin/ai/masaic/openresponses/api/client/MasaicStreamingService.kt
+++ b/src/main/kotlin/ai/masaic/openresponses/api/client/MasaicStreamingService.kt
@@ -74,7 +74,7 @@ class MasaicStreamingService(
             if (tooManyToolCalls(responseInputItems)) {
                 emitTooManyToolCallsError()
                 throw UnsupportedOperationException(
-                    "Too many tool calls. Increase the limit by setting MASAIC_MAX_TOOL_CALLS environment variable.",
+                    "Too many tool calls. Increase the limit by setting OPEN_RESPONSES_MAX_TOOL_CALLS environment variable.",
                 )
             }
 


### PR DESCRIPTION
## Summary
- correct env var name in MasaicStreamingService error message

## Testing
- `./gradlew test --tests "*MasaicStreamingService*"` *(fails: unable to download Gradle distribution)*

------
https://chatgpt.com/codex/tasks/task_e_683fe6e4806c832ab5c331ca27e0331d