### PR TITLE
Assistant Message With Tool Call Response Is Skipped In Subsequent Model Calls

### DIFF
--- a/platform/build.gradle.kts
+++ b/platform/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 // Determine the version - allow override from command line
 val projectVersion = (findProperty("buildVersion") as String?)
-    ?.takeIf { it.isNotBlank() } ?: "0.8.2"
+    ?.takeIf { it.isNotBlank() } ?: "0.8.3"
 
 allprojects {
     group = "ai.masaic.agc"

--- a/platform/open-responses-core/src/main/kotlin/ai/masaic/openresponses/api/client/MasaicToolHandler.kt
+++ b/platform/open-responses-core/src/main/kotlin/ai/masaic/openresponses/api/client/MasaicToolHandler.kt
@@ -379,6 +379,8 @@ class MasaicToolHandler(
                         .content()
                         .get()
                         .isNotBlank()
+            }.filter {
+                it.finishReason() != ChatCompletion.Choice.FinishReason.TOOL_CALLS
             }.forEach {
                 logger.trace { "Adding text content to parked items" }
                 parked.add(
@@ -681,7 +683,8 @@ class MasaicToolHandler(
                         .message()
                         .get()
                         .content()
-                        .isNotEmpty()
+                        .isNotEmpty() &&
+                    !response.output().any { it.isFunctionCall() }
             }
         logger.trace { "Found ${messageOutputs.size} message outputs to park" }
         messageOutputs.forEach {

--- a/platform/open-responses-core/src/main/kotlin/ai/masaic/openresponses/api/extensions/Extensions.kt
+++ b/platform/open-responses-core/src/main/kotlin/ai/masaic/openresponses/api/extensions/Extensions.kt
@@ -24,7 +24,7 @@ suspend fun ResponseCreateParams.Builder.fromBody(
 ): ResponseCreateParams.Builder {
     // Set required parameters
     if (body.previousResponseId().isPresent) {
-        responseStore.getResponse(body.previousResponseId().get()) ?: throw ResponseNotFoundException("Previous response not found")
+        val previousResponse = responseStore.getResponse(body.previousResponseId().get()) ?: throw ResponseNotFoundException("Previous response not found")
         var previousInputItems =
             responseStore
                 .getInputItems(body.previousResponseId().get())
@@ -48,7 +48,21 @@ suspend fun ResponseCreateParams.Builder.fromBody(
                 )
             }
 
-        previousInputItems.addAll(previousResponseOutputItems.map { objectMapper.convertValue(it, ResponseInputItem::class.java) })
+        val hasToolCalls = previousResponse.output().any { it.isFunctionCall() }
+        previousInputItems.addAll(
+            previousResponseOutputItems
+                .map { objectMapper.convertValue(it, ResponseInputItem::class.java) }
+                .filter { item ->
+                    val role =
+                        when {
+                            item.isMessage() -> item.asMessage().role().toString()
+                            item.isResponseOutputMessage() -> item.asResponseOutputMessage()._role().toString()
+                            else -> ""
+                        }
+                    val isAssistantMessageFromToolCall = hasToolCalls && role.lowercase() == "assistant"
+                    !isAssistantMessageFromToolCall && item !in previousInputItems
+                },
+        )
         previousInputItems.addAll(currentInputItems)
         if (body.instructions().isPresent &&
             previousInputItems.any {

--- a/platform/open-responses-core/src/test/kotlin/ai/masaic/openresponses/api/client/MasaicToolHandlerTest.kt
+++ b/platform/open-responses-core/src/test/kotlin/ai/masaic/openresponses/api/client/MasaicToolHandlerTest.kt
@@ -70,7 +70,7 @@ class MasaicToolHandlerTest {
             ChatCompletion.Choice
                 .builder()
                 .message(chatMessage)
-                .finishReason(ChatCompletion.Choice.FinishReason.TOOL_CALLS)
+                .finishReason(ChatCompletion.Choice.FinishReason.STOP)
                 .index(0)
                 .logprobs(null)
                 .build()
@@ -568,16 +568,15 @@ class MasaicToolHandlerTest {
         // When
         val result = runBlocking { handler.handleMasaicToolCall(chatCompletion, params, null, mockk()) }
 
-        // Then: We expect a Continue result with 6 items
+        // Then: We expect a Continue result with 5 items
         assertTrue(result is MasaicToolCallResult.Continue)
         val items = (result as MasaicToolCallResult.Continue).items
         // 1) Original user message
-        // 2) Assistant message with tools (parked)
-        // 3) First tool call
-        // 4) First tool result
-        // 5) Second tool call
-        // 6) Second tool result
-        assertEquals(6, items.size)
+        // 2) First tool call
+        // 3) First tool result
+        // 4) Second tool call
+        // 5) Second tool result
+        assertEquals(5, items.size)
 
         // Verify tool execution was observed twice
 //        verify(exactly = 2) { runBlocking { telemetryService.withClientObservation<Any>(any(), any<Observation>(), any()) } }
@@ -856,14 +855,13 @@ class MasaicToolHandlerTest {
         // When
         val result = runBlocking { handler.handleMasaicToolCall(chatCompletion, params, null, mockk(relaxed = true)) }
 
-        // Then: We expect a Continue result with 4 items
+        // Then: We expect a Continue result with 3 items
         assertTrue(result is MasaicToolCallResult.Continue)
         val items = (result as MasaicToolCallResult.Continue).items
         // 1) The original user input as a ResponseInputItem
-        // 2) The assistant text message from the completion
-        // 3) The function call
-        // 4) The function call output
-        assertEquals(4, items.size)
+        // 2) The function call
+        // 3) The function call output
+        assertEquals(3, items.size)
 
         // Verify function call and output
         val functionCall = items[1]

--- a/platform/open-responses-core/src/test/kotlin/ai/masaic/openresponses/api/extensions/ExtensionsTest.kt
+++ b/platform/open-responses-core/src/test/kotlin/ai/masaic/openresponses/api/extensions/ExtensionsTest.kt
@@ -113,6 +113,7 @@ class ExtensionsTest {
         
             // Mock previous response
             val mockResponse = mockk<Response>()
+            every { mockResponse.output() } returns emptyList()
             coEvery { responseStore.getResponse(previousResponseId) } returns mockResponse
         
             // Mock previous input items
@@ -139,6 +140,7 @@ class ExtensionsTest {
                             .role(EasyInputMessage.Role.USER)
                             .build()
                     every { isResponseOutputMessage() } returns false
+                    every { isMessage() } returns false
                 }
             val convertedInputItem2 =
                 mockk<ResponseInputItem> {
@@ -152,6 +154,7 @@ class ExtensionsTest {
                             .role(EasyInputMessage.Role.ASSISTANT)
                             .build()
                     every { isResponseOutputMessage() } returns false
+                    every { isMessage() } returns false
                 }
             val convertedOutputItem =
                 mockk<ResponseInputItem> {
@@ -165,6 +168,7 @@ class ExtensionsTest {
                             .role(EasyInputMessage.Role.USER)
                             .build()
                     every { isResponseOutputMessage() } returns false
+                    every { isMessage() } returns false
                 }
             every { objectMapper.convertValue(previousInputItem1, ResponseInputItem::class.java) } returns convertedInputItem1
             every { objectMapper.convertValue(previousInputItem2, ResponseInputItem::class.java) } returns convertedInputItem2
@@ -183,6 +187,7 @@ class ExtensionsTest {
                             .role(EasyInputMessage.Role.ASSISTANT)
                             .build()
                     every { isResponseOutputMessage() } returns false
+                    every { isMessage() } returns false
                 }
             val currentInputItems = listOf(currentInputItem)
         


### PR DESCRIPTION
For any tool call response with assistant message was appended to input message items and history which models like Claude are rejecting. Although, those assistant messages with tool call are meant for progress information for end user and has nothing to do with real message stack.